### PR TITLE
[WIP] FIX: Use top-level namespace for base classes

### DIFF
--- a/app/jobs/regular/saved_search_notification.rb
+++ b/app/jobs/regular/saved_search_notification.rb
@@ -3,7 +3,7 @@
 require_dependency 'system_message'
 
 module Jobs
-  class SavedSearchNotification < Jobs::Base
+  class SavedSearchNotification < ::Jobs::Base
 
     sidekiq_options queue: 'low'
 

--- a/app/jobs/scheduled/schedule_saved_searches.rb
+++ b/app/jobs/scheduled/schedule_saved_searches.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Jobs
-  class ScheduleSavedSearches < Jobs::Scheduled
+  class ScheduleSavedSearches < ::Jobs::Scheduled
 
     SEARCH_INTERVAL = 1.day
 


### PR DESCRIPTION
Zeitwerk is failing when we are searching for Jobs::Onceoff and Jobs::Base without going back to the top-level namespace (this is correlated to the fact that we got Onceoff base class and module with the same name). 

I noticed that in plugins we are using sometimes :: and sometimes not and that gives me comfort that this change will not break anything.

Travis error: https://travis-ci.org/discourse/discourse/jobs/585072364