### PR TITLE
FIX: Allow empty saved searches set

### DIFF
--- a/lib/guardian_extensions.rb
+++ b/lib/guardian_extensions.rb
@@ -2,6 +2,8 @@
 
 module SavedSearches::GuardianExtensions
   def can_use_saved_searches?
-    SiteSetting.saved_searches_enabled? && (is_staff? || user.has_trust_level?(SiteSetting.saved_searches_min_trust_level))
+    SiteSetting.saved_searches_enabled? &&
+      authenticated? &&
+      (is_staff? || user.has_trust_level?(SiteSetting.saved_searches_min_trust_level))
   end
 end

--- a/spec/requests/saved_searches_controller_spec.rb
+++ b/spec/requests/saved_searches_controller_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe SavedSearches::SavedSearchesController do
+  fab!(:user) { Fabricate(:user) }
+
+  before do
+    SiteSetting.saved_searches_enabled = true
+  end
+
+  context "#update" do
+    it "does not work when not logged in" do
+      put "/u/#{user.username}/preferences/saved-searches.json"
+      expect(response.status).to eq(403)
+    end
+
+    it "can create and update saved searches" do
+      saved_search = Fabricate(:saved_search, user: user, query: "discount", frequency: SavedSearch.frequencies[:daily])
+      sign_in(user)
+
+      put "/u/#{user.username}/preferences/saved-searches.json", params: {
+        searches: {
+          0 => { query: "discount", frequency: "weekly" },
+          1 => { query: "discourse", frequency: "immediately" }
+        }
+      }
+
+      expect(response.status).to eq(200)
+      expect(user.saved_searches.size).to eq(2)
+
+      expect(saved_search.reload.query).to eq("discount")
+      expect(saved_search.frequency).to eq(SavedSearch.frequencies[:weekly])
+
+      new_saved_search = user.saved_searches.last
+      expect(new_saved_search.query).to eq("discourse")
+      expect(new_saved_search.frequency).to eq(SavedSearch.frequencies[:immediately])
+    end
+
+    it "can delete all saved searches" do
+      Fabricate(:saved_search, user: user)
+      sign_in(user)
+
+      put "/u/#{user.username}/preferences/saved-searches.json"
+      expect(response.status).to eq(200)
+      expect(user.saved_searches.size).to eq(0)
+    end
+  end
+end


### PR DESCRIPTION
This can be the case when the user wants to delete all existing saved
searches.