### PR TITLE
FIX: Don’t create posts for trashed topics

### DIFF
--- a/app/jobs/regular/execute_saved_searches.rb
+++ b/app/jobs/regular/execute_saved_searches.rb
@@ -104,7 +104,7 @@ module Jobs
       custom_field_name = "pm_saved_search_results_#{user.id}"
 
       # Find existing topic for this search term
-      if tcf = TopicCustomField.where(name: custom_field_name, value: saved_search.query).last
+      if tcf = TopicCustomField.joins(:topic).where(name: custom_field_name, value: saved_search.query).last
         PostCreator.create!(
           Discourse.system_user,
           topic_id: tcf.topic_id,


### PR DESCRIPTION
Currently there’s a bug when creating digests: if an existing topic linked to a saved search has been trashed, then we try to create a new post linked to this topic and the `PostCreator` object raises an error since it can’t find the provided topic.

This PR addresses this issue simply by adding a join to the query that is finding the existing topic custom field. This way if the related topic has been trashed then we’ll create a new topic instead of trying to reuse the trashed one.