### PR TITLE
FIX: Ensure jobs are skipped when disabled

### DIFF
--- a/app/jobs/scheduled/schedule_saved_searches.rb
+++ b/app/jobs/scheduled/schedule_saved_searches.rb
@@ -5,6 +5,8 @@ module Jobs
     every 5.minutes
 
     def execute(args)
+      return if !SiteSetting.saved_searches_enabled
+
       SavedSearch
         .distinct
         .pluck(:user_id)

--- a/spec/jobs/scheduled/schedule_saved_searches_spec.rb
+++ b/spec/jobs/scheduled/schedule_saved_searches_spec.rb
@@ -6,9 +6,21 @@ describe Jobs::ScheduleSavedSearches do
   fab!(:saved_search_1) { Fabricate(:saved_search) }
   fab!(:saved_search_2) { Fabricate(:saved_search) }
 
-  it "schedules one job per saved search" do
-    expect { described_class.new.execute({}) }.to change {
-      Jobs::ExecuteSavedSearches.jobs.count
-    }.by(2)
+  context "when plugin is enabled" do
+    before { SiteSetting.saved_searches_enabled = true }
+
+    it "schedules one job per saved search" do
+      expect { described_class.new.execute({}) }.to change {
+        Jobs::ExecuteSavedSearches.jobs.count
+      }.by(2)
+    end
+  end
+
+  context "when plugin is disabled" do
+    it "schedules one job per saved search" do
+      expect { described_class.new.execute({}) }.not_to change {
+        Jobs::ExecuteSavedSearches.jobs.count
+      }
+    end
   end
 end


### PR DESCRIPTION
This also fixes the debug line that was causing an exception to be raised when the quick search query was not running.