### PR TITLE
DEV: Migrate `SavedSearchResult#notification_id` to `bigint`

### DIFF
--- a/db/migrate/20240827033810_change_notification_id_from_int_to_bigint.rb
+++ b/db/migrate/20240827033810_change_notification_id_from_int_to_bigint.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+class ChangeNotificationIdFromIntToBigint < ActiveRecord::Migration[7.1]
+  def up
+    execute("ALTER TABLE saved_search_results ALTER COLUMN notification_id TYPE bigint")
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
Discourse Core has migrated its column type to `bigint`. Note that we are running `ALTER TABLE` because there is little risk in locking this table during the migration since the table's activity is not expected to be high and the number of rows are expected to be small.
